### PR TITLE
Adds uppercase TRUE and FALSE literals.

### DIFF
--- a/grammars/dm.cson
+++ b/grammars/dm.cson
@@ -140,7 +140,7 @@
   'constants':
     'patterns': [
       {
-        'match': '\\b(true|false|null)\\b'
+        'match': '\\b(true|false|TRUE|FALSE|null)\\b'
         'name': 'constant.language.source.dm'
       }
       {


### PR DESCRIPTION
`true` and `false` are not native in DM, but `TRUE` and `FALSE` are.
