### PR TITLE
Add regex for string macros

### DIFF
--- a/grammars/dm.cson
+++ b/grammars/dm.cson
@@ -166,6 +166,10 @@
         'name': 'string.quoted.double.source.dm'
         'patterns': [
           {
+            'match': '\\\\(?:the|The|a|an|A|An|he|He|she|She|his|His|himself|herself|hers|proper|improper|th|s|icon|ref|roman|Roman|\\.\\.\\.)(?=$|[[:space:]"])'
+            'name': 'support.function.builtin.source.dm'
+          }
+          {
             'match': '\\\\.'
             'name': 'constant.character.escape.source.dm'
           }


### PR DESCRIPTION
Highlights macros like `\the` when used in strings. List grabbed from [the ref](http://www.byond.com/docs/ref/info.html#/DM/text/macros). Singe-char 'macros' from that list fall back to generic escaped character highlight. 
